### PR TITLE
When adding an entry into constant pool, it's index should be ≤ 65534, or ≤ 65533 if it's wide

### DIFF
--- a/janino/src/org/codehaus/janino/util/ClassFile.java
+++ b/janino/src/org/codehaus/janino/util/ClassFile.java
@@ -493,7 +493,9 @@ class ClassFile implements Annotatable {
         if (index != null) return index.shortValue();
 
         int res = this.constantPool.size();
-        if (res > 0xFFFF) {
+
+        // `res` will become the new entry's index, so `res` must be ≤ 65534, or ≤ 65533 if the entry is wide
+        if (res >= 0xFFFF || (cpi.isWide() && res >= 0xFFFF - 1)) {
             throw new JaninoRuntimeException(
                 "Constant pool for class "
                 + this.getThisClassName()


### PR DESCRIPTION
As stated in JSL7 4.1, the value of the `constant_pool_count` item is equal to the number of entries in the constant_pool table plus one. Since `constant_pool_count`'s max value is 65535, then the index of an entry in the constant pool should be within the range [1, 65534], or [1, 65533] if the entry itself is wide.

This patch ensures this semantics. All tests suits (including the updated one) in `common-compiler-tests`, `janino-tests` passed.

In addtition, I've verified Oracle's javac respects the same 65534 limitation -- 65534 was the max index of constant pool I could get before I ran into `error: too many constants` from javac :-)

![javac_constant_pool](https://cloud.githubusercontent.com/assets/15843379/17083811/e75efdcc-51dd-11e6-81ab-3cdcbb187b65.png)
_image: max index of constant pool from javac is 65534_