### PR TITLE
add if-block for short constant with sipush

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -10358,6 +10358,10 @@ class UnitCompiler {
                 this.writeOpcode(locatable, Opcode.BIPUSH);
                 this.writeByte((byte) iv);
             } else
+            if (iv >= Short.MIN_VALUE && iv <= Short.MAX_VALUE) {
+                this.writeOpcode(locatable, Opcode.SIPUSH);
+                this.writeShort((short) iv);
+            } else
             {
                 this.writeLdc(locatable, this.addConstantIntegerInfo(iv));
             }


### PR DESCRIPTION
This PR addresses an issue #33. This PR generates [`sipush`](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-6.html#jvms-6.5.sipush) java bytecode instruction for short integer constant.

This issue comes from [discussions](https://github.com/apache/spark/pull/19518#issuecomment-346828180) in a PR for Apach Spark.
