### PR TITLE
Fix negation of integer literals of the minimal values of int or long.

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -5877,8 +5877,7 @@ class UnitCompiler {
         });
     }
     @Nullable private Object
-    getNegatedConstantValue2(Rvalue rv) throws CompileException {
-        Object cv = this.getConstantValue(rv);
+    getNegatedConstantValueHelper(Object cv) {
         if (cv instanceof Byte)    return new Byte((byte) -((Byte) cv).byteValue());
         if (cv instanceof Short)   return new Short((short) -((Short) cv).shortValue());
         if (cv instanceof Integer) return new Integer(-((Integer) cv).intValue());
@@ -5888,7 +5887,16 @@ class UnitCompiler {
         return UnitCompiler.NOT_CONSTANT;
     }
     @Nullable private Object
+    getNegatedConstantValue2(Rvalue rv) throws CompileException {
+        Object cv = this.getConstantValue(rv);
+        return getNegatedConstantValueHelper(cv);
+    }
+    @Nullable private Object
     getNegatedConstantValue2(UnaryOperation uo) throws CompileException {
+        // special handling for negating Integer.MIN_VALUE or Long.MIN_VALUE
+        if (uo.operator == "-" && uo.operand instanceof IntegerLiteral) {   // SUPPRESS CHECKSTYLE StringLiteralEquality
+            return this.getNegatedConstantValueHelper(this.getNegatedConstantValue(uo.operand));
+        }
         return (
             uo.operator == "+" ? this.getNegatedConstantValue(uo.operand) : // SUPPRESS CHECKSTYLE StringLiteralEquality
             uo.operator == "-" ? this.getConstantValue(uo.operand)        : // SUPPRESS CHECKSTYLE StringLiteralEquality

--- a/janino/src/test/java/org/codehaus/janino/tests/CompilerTest.java
+++ b/janino/src/test/java/org/codehaus/janino/tests/CompilerTest.java
@@ -433,6 +433,15 @@ class CompilerTest {
         s.getClassLoader().loadClass("a.TestLocalVarTable");
     }
 
+    // https://github.com/codehaus/janino/issues/41
+    @Test public void
+    testIntegerLiteralNegation() throws Exception {
+        SimpleCompiler s = new SimpleCompiler();
+        s.setDebuggingInformation(true, true, true);
+        s.cook(new FileInputStream(CompilerTest.RESOURCE_DIR + "/a/TestIntegerLiteralNegation.java"));
+        s.getClassLoader().loadClass("a.TestIntegerLiteralNegation");
+    }
+
     public static List<ClassFile>
     doCompile(
         boolean   debugSource,

--- a/janino/src/test/resources/a/TestIntegerLiteralNegation.java
+++ b/janino/src/test/resources/a/TestIntegerLiteralNegation.java
@@ -1,0 +1,11 @@
+package a;
+
+// Issue #41 : Invalid integer literal "9223372036854775808L"
+public
+class TestIntegerLiteralNegation {
+    void foo() {
+        int x = -(-2147483648);
+        long y = -(-9223372036854775808L);
+    }
+}
+


### PR DESCRIPTION
This PR fixes https://github.com/janino-compiler/janino/issues/41, where Janino fails to compile negation of integer literals that are of the minimal values of their types, i.e.
```
int x = -(-2147483648);
long y = -(-9223372036854775808L);
```

The problem was that, such expression would have the following AST structure:
```
UnaryOperation -
  operand: ParenthesizedExpression
    value: UnaryOperation -
      operand: IntegerLiteral 9223372036854775808L
```
and when Janino tries to constant fold this tree, the stack trace goes like:
```
	at org.codehaus.janino.UnitCompiler.compileException(UnitCompiler.java:12127)
	at org.codehaus.janino.UnitCompiler.getConstantValue2(UnitCompiler.java:5674)
	at org.codehaus.janino.UnitCompiler.access$10300(UnitCompiler.java:212)
	at org.codehaus.janino.UnitCompiler$13.visitIntegerLiteral(UnitCompiler.java:5309)
	at org.codehaus.janino.Java$IntegerLiteral.accept(Java.java:5282)
	at org.codehaus.janino.UnitCompiler.getConstantValue(UnitCompiler.java:5280) // uh-oh
	at org.codehaus.janino.UnitCompiler.getNegatedConstantValue2(UnitCompiler.java:5881) // sees the inner unary minus so ask for the "un-negated" constant value
	at org.codehaus.janino.UnitCompiler.access$11200(UnitCompiler.java:212)
	at org.codehaus.janino.UnitCompiler$14.visitUnaryOperation(UnitCompiler.java:5841) // this is working on the outer unary minus, so ask for the negated constant value
```

This PR adds a special case handling so that if the immediate child of a unary minus is an integer literal, invoke `getNegatedConstantValue` on it first to make sure it hits the correct handling for minimal values.