### PR TITLE
Report compile error when the number of slots required by a method is beyond the Class file limitation (255)

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/MethodDescriptor.java
+++ b/janino/src/main/java/org/codehaus/janino/MethodDescriptor.java
@@ -81,6 +81,19 @@ class MethodDescriptor {
     }
 
     /**
+     * @return The number of slots required for invoking this method.
+     */
+    public int
+    parameterSize() {
+        int paramSize = 0;
+        String[] paramFds = this.parameterFds;
+        for (int i = 0; i < paramFds.length; i++) {
+            paramSize += Descriptor.size(paramFds[i]);
+        }
+        return paramSize;
+    }
+
+    /**
      * @return The "method descriptor" (JVMS 4.3.3)
      */
     @Override public String

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -3203,6 +3203,13 @@ class UnitCompiler {
             );
         }
 
+        {
+            MethodDescriptor md = new MethodDescriptor(mi.getDescriptor());
+            if (md.parameterSize() > ClassFile.MAX_PARAMETERS) {
+                throw new InternalCompilerException("too many arguments: \"" + md.toString() + "\"");
+            }
+        }
+
         // Add method annotations with retention != SOURCE.
         this.compileAnnotations(fd.modifiers.annotations, mi, classFile);
 

--- a/janino/src/main/java/org/codehaus/janino/util/ClassFile.java
+++ b/janino/src/main/java/org/codehaus/janino/util/ClassFile.java
@@ -60,6 +60,11 @@ public
 class ClassFile implements Annotatable {
 
     /**
+     * The maximum number of slots allowed for parameters, as defined by JVMS7 4.11, bullet 7.
+     */
+    public static final int MAX_PARAMETERS = 255;
+
+    /**
      * Unchecked exception that represents an error condition that could occur during processing of class files, e.g.
      * reading a corrupt class file, or an overflow of the constant pool.
      */


### PR DESCRIPTION
Currently, when Janino compiles a method declared with a parameter size beyond the JVM limit, it silently allows the code to compile without reporting an error, leaving the generated class subject to getting `ClassFormatError` when loaded by the JVM at runtime.

This change detects the number of slots required for parameters when compiling a method, so that such error gets reported at compile time.

Manually verified this change reports appropriate error message when compiling a method declared as `public void foo(long arg1, long arg2, long arg3, long arg4, long arg5, long arg6, long arg7, long arg8, long arg9, long arg10, long arg11, long arg12, long arg13, long arg14, long arg15, long arg16, long arg17, long arg18, long arg19, long arg20, long arg21, long arg22, long arg23, long arg24, long arg25, long arg26, long arg27, long arg28, long arg29, long arg30, long arg31, long arg32, long arg33, long arg34, long arg35, long arg36, long arg37, long arg38, long arg39, long arg40, long arg41, long arg42, long arg43, long arg44, long arg45, long arg46, long arg47, long arg48, long arg49, long arg50, long arg51, long arg52, long arg53, long arg54, long arg55, long arg56, long arg57, long arg58, long arg59, long arg60, long arg61, long arg62, long arg63, long arg64, long arg65, long arg66, long arg67, long arg68, long arg69, long arg70, long arg71, long arg72, long arg73, long arg74, long arg75, long arg76, long arg77, long arg78, long arg79, long arg80, long arg81, long arg82, long arg83, long arg84, long arg85, long arg86, long arg87, long arg88, long arg89, long arg90, long arg91, long arg92, long arg93, long arg94, long arg95, long arg96, long arg97, long arg98, long arg99, long arg100, long arg101, long arg102, long arg103, long arg104, long arg105, long arg106, long arg107, long arg108, long arg109, long arg110, long arg111, long arg112, long arg113, long arg114, long arg115, long arg116, long arg117, long arg118, long arg119, long arg120, long arg121, long arg122, long arg123, long arg124, long arg125, long arg126, long arg127, long arg128) { }` whose parameter size is `256`.