### PR TITLE
Add Automatic-Module-Name

### DIFF
--- a/janino-parent/pom.xml
+++ b/janino-parent/pom.xml
@@ -88,6 +88,9 @@
 
             <!-- This line is required, otherwise the maven-bundle-plugin doesn't add the OSGi lines. -->
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.janino</Automatic-Module-Name>
+            </manifestEntries>
           </archive> 
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR adds an Automatic-Module-Name to the MANIFEST.MF
so projects that use the java module system can declare janino as
a dependency until janino adds a module-info.java.