### PR TITLE
Handle overloaded static on-demand imports.

### DIFF
--- a/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/JavaSourceClassLoaderTest.java
+++ b/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/JavaSourceClassLoaderTest.java
@@ -89,14 +89,23 @@ class JavaSourceClassLoaderTest {
         jscl.loadClass("test.Func1");
     }
 
-    @Test public void
-    testCircularStaticImports() throws Exception {
-        AbstractJavaSourceClassLoader jscl = this.compilerFactory.newJavaSourceClassLoader(
-            ClassLoader.getSystemClassLoader().getParent()
-        );
-        jscl.setSourcePath(new File[] { new File("src/test/resources/testCircularStaticImports/") });
-        jscl.loadClass("test.Func1");
-    }
+   @Test public void
+   testCircularStaticImports() throws Exception {
+      AbstractJavaSourceClassLoader jscl = this.compilerFactory.newJavaSourceClassLoader(
+        ClassLoader.getSystemClassLoader().getParent()
+      );
+      jscl.setSourcePath(new File[] { new File("src/test/resources/testCircularStaticImports/") });
+      jscl.loadClass("test.Func1");
+   }
+
+   @Test public void
+   testOverloadedStaticImports() throws Exception {
+      AbstractJavaSourceClassLoader jscl = this.compilerFactory.newJavaSourceClassLoader(
+        ClassLoader.getSystemClassLoader().getParent()
+      );
+      jscl.setSourcePath(new File[] { new File("src/test/resources/testOverloadedStaticImports/") });
+      jscl.loadClass("test.StaticImports");
+   }
 
     private static ClassLoader
     getExtensionsClassLoader() throws ClassNotFoundException {

--- a/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/C1.java
+++ b/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/C1.java
@@ -1,0 +1,7 @@
+package test;
+
+public class C1 {
+   public static String testOverload(int param) {
+      return "Hello World (int): "  + param;
+   }
+}

--- a/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/C2.java
+++ b/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/C2.java
@@ -1,0 +1,10 @@
+package test;
+
+public class C2 {
+   public static String testOverload(long param) {
+      return "Hello World (long): "  + param;
+   }
+   public static String testOverload(short param) {
+      return "Hello World (short): "  + param;
+   }
+}

--- a/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/StaticImports.java
+++ b/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/StaticImports.java
@@ -1,0 +1,12 @@
+package test;
+
+import static test.C1.*;
+import static test.C2.*;
+
+public class StaticImports {
+   public void execute() {
+     System.out.println(testOverload((short) 1));
+     System.out.println(testOverload((long) 2));
+     System.out.println(testOverload((int) 3));
+   }
+}

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -9152,22 +9152,21 @@ class UnitCompiler {
             if (iMethod != null) break FIND_METHOD;
 
             // Static method declared through static-import-on-demand?
+           List<IMethod> candidates = new ArrayList<IMethod>();
             for (Object o : this.importStaticOnDemand(mi.methodName)) {
 
-                if (!(o instanceof IMethod)) continue;
-                IMethod im = (IMethod) o;
+               if (!(o instanceof IMethod)) continue;
 
-                if (iMethod != null) {
-                    this.compileError(
-                        "Ambiguous static method import: \""
-                        + iMethod.toString()
-                        + "\" vs. \""
-                        + im.toString()
-                        + "\""
-                    );
-                }
+               candidates.add((IMethod) o);
+            }
 
-                iMethod = im;
+            if (!candidates.isEmpty()) {
+               iMethod = (IMethod) this.findMostSpecificIInvocable(
+                 mi,
+                 (IMethod[]) candidates.toArray(new IMethod[candidates.size()]),
+                 mi.arguments,
+                 mi.getEnclosingScope()
+               );
             }
             if (iMethod != null) break FIND_METHOD;
 


### PR DESCRIPTION
When overloaded static methods are imported, the most specific one should be bound to the corresponding method invocation.

Fix for [this issue.](https://github.com/janino-compiler/janino/issues/93)