### PR TITLE
Issue #93 : Fix overloaded single static method import

### DIFF
--- a/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/JavaSourceClassLoaderTest.java
+++ b/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/JavaSourceClassLoaderTest.java
@@ -107,6 +107,15 @@ class JavaSourceClassLoaderTest {
         jscl.loadClass("test.StaticImports");
     }
 
+    @Test public void
+    testOverloadedSingleStaticImport() throws Exception {
+        AbstractJavaSourceClassLoader jscl = this.compilerFactory.newJavaSourceClassLoader(
+                ClassLoader.getSystemClassLoader().getParent()
+        );
+        jscl.setSourcePath(new File[] { new File("src/test/resources/testOverloadedStaticImports/") });
+        jscl.loadClass("test.SingleStaticImport");
+    }
+
     private static ClassLoader
     getExtensionsClassLoader() throws ClassNotFoundException {
 

--- a/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/SingleStaticImport.java
+++ b/commons-compiler-tests/src/test/resources/testOverloadedStaticImports/test/SingleStaticImport.java
@@ -1,0 +1,13 @@
+
+package test;
+
+import static test.C2.testOverload;
+
+public
+class SingleStaticImport {
+    
+    public void
+    execute() {
+        System.out.println(testOverload((long) 2));
+    }
+}

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -9115,21 +9115,22 @@ class UnitCompiler {
             }
 
             // Static method declared through single static import?
-            iMethod = null;
-            for (IMethod im : Iterables.filterByClass(this.importSingleStatic(mi.methodName), IMethod.class)) {
-
-                if (iMethod != null && iMethod != im) {
-                    this.compileError(
-                        "Ambiguous static method import: \""
-                        + iMethod.toString()
-                        + "\" vs. \""
-                        + im.toString()
-                        + "\""
+            {
+                IMethod[] candidates = (IMethod[]) Iterables.toArray(
+                        Iterables.filterByClass(this.importSingleStatic(mi.methodName), IMethod.class),
+                        IMethod.class
+                );
+    
+                if (candidates.length > 0) {
+                    iMethod = (IMethod) this.findMostSpecificIInvocable(
+                            mi,
+                            candidates,
+                            mi.arguments,
+                            mi.getEnclosingScope()
                     );
+                    break FIND_METHOD;
                 }
-                iMethod = im;
             }
-            if (iMethod != null) break FIND_METHOD;
 
             // Static method declared through static-import-on-demand?
             {
@@ -9556,10 +9557,12 @@ class UnitCompiler {
                                 theNonAbstractMethod = m;
                             } else
                             {
-                                throw new InternalCompilerException(
-                                    "SNO: Types declaring \""
-                                    + theNonAbstractMethod
-                                    + "\" are not assignable"
+                                this.compileError(
+                                        "Ambiguous static method import: \""
+                                                + theNonAbstractMethod.toString()
+                                                + "\" vs. \""
+                                                + m.toString()
+                                                + "\""
                                 );
                             }
                         }


### PR DESCRIPTION
Overloaded static import is broken since 3.0.13, release 3.0.14 introduced a fix but this fix did not fix the problem for single static method imports.

Here is a test that describes the problem along with a possible fix.