### PR TITLE
Issue #116: replace operand to final target type if boxing conversion and widening reference conversion happen together

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -10875,6 +10875,8 @@ class UnitCompiler {
                 }
                 if (this.isWideningReferenceConvertible(boxedType, targetType)) {
                     this.boxingConversion(locatable, sourceType, boxedType);
+                    this.getCodeContext().popOperand(boxedType.getDescriptor());
+                    this.getCodeContext().pushOperand(targetType.getDescriptor());
                     return true;
                 }
             }


### PR DESCRIPTION
There's a bug discovered in #116 which seems to miss replacing operand to final target type if both of boxing conversion and widening reference conversion happen together.

This patch adds new UT to reproduce #116 - it fails on latest master branch, and passes with this PR.