### PR TITLE
Issue #119: Guarantee executing popOperand() in popUninitializedVariableOperand() via moving popOperand() out of "assert"

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/CodeContext.java
+++ b/janino/src/main/java/org/codehaus/janino/CodeContext.java
@@ -1364,7 +1364,8 @@ class CodeContext {
      */
     public void
     popUninitializedVariableOperand() {
-        assert this.popOperand() instanceof StackMapTableAttribute.UninitializedVariableInfo;
+        VerificationTypeInfo result = this.popOperand();
+        assert result instanceof StackMapTableAttribute.UninitializedVariableInfo;
     }
 
     /**


### PR DESCRIPTION
There's a bug discovered in #119 which seems to execute "stateful" operation into "assert". The execution is not guaranteed, and leads to inconsistent stack map.

This patch adds new UT to reproduce #119 - it fails on latest master branch, and passes with this PR.