### PR TITLE
Fix the bug that handles NaN comparisons incorrectly

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -11748,7 +11748,7 @@ class UnitCompiler {
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
      */
     private void
-    ifNumeric(Locatable locatable, String op, int opIdx, Offset dst) {
+    ifNumeric(Locatable locatable, String origOp, int opIdx, Offset dst) {
         assert opIdx >= UnitCompiler.EQ && opIdx <= UnitCompiler.LE;
 
         VerificationTypeInfo topOperand = this.getCodeContext().peekOperand();
@@ -11761,7 +11761,7 @@ class UnitCompiler {
             || topOperand == StackMapTableAttribute.FLOAT_VARIABLE_INFO
             || topOperand == StackMapTableAttribute.DOUBLE_VARIABLE_INFO
         ) {
-            this.cmp(locatable, op);
+            this.cmp(locatable, origOp);
             this.ifxx(locatable, opIdx, dst);
         } else
         {
@@ -11856,7 +11856,7 @@ class UnitCompiler {
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
      */
     private void
-    cmp(Locatable locatable, String op) {
+    cmp(Locatable locatable, String origOp) {
         VerificationTypeInfo operand2 = this.getCodeContext().currentInserter().getStackMap().peekOperand();
         this.getCodeContext().popOperand();
         VerificationTypeInfo operand1 = this.getCodeContext().currentInserter().getStackMap().peekOperand();
@@ -11866,10 +11866,10 @@ class UnitCompiler {
             this.write(Opcode.LCMP);
         } else
         if (operand1 == StackMapTableAttribute.FLOAT_VARIABLE_INFO && operand2 == StackMapTableAttribute.FLOAT_VARIABLE_INFO) {
-            this.write(op == ">" || op == ">=" ? Opcode.FCMPL : Opcode.FCMPG);
+            this.write(origOp == ">" || origOp == ">=" ? Opcode.FCMPL : Opcode.FCMPG);
         } else
         if (operand1 == StackMapTableAttribute.DOUBLE_VARIABLE_INFO && operand2 == StackMapTableAttribute.DOUBLE_VARIABLE_INFO) {
-            this.write(op == ">" || op == ">=" ? Opcode.DCMPL : Opcode.DCMPG);
+            this.write(origOp == ">" || origOp == ">=" ? Opcode.DCMPL : Opcode.DCMPG);
         } else
         {
             throw new AssertionError(operand1 + " and " + operand2);

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -4389,7 +4389,7 @@ class UnitCompiler {
                 this.compileGetValue(bo.rhs);
                 this.numericPromotion(bo.rhs, this.convertToPrimitiveNumericType(bo.rhs, rhsType), promotedType);
 
-                this.ifNumeric(bo, opIdx, dst);
+                this.ifNumeric(bo, bo.operator, opIdx, dst);
                 return;
             }
 
@@ -11748,7 +11748,7 @@ class UnitCompiler {
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
      */
     private void
-    ifNumeric(Locatable locatable, int opIdx, Offset dst) {
+    ifNumeric(Locatable locatable, String op, int opIdx, Offset dst) {
         assert opIdx >= UnitCompiler.EQ && opIdx <= UnitCompiler.LE;
 
         VerificationTypeInfo topOperand = this.getCodeContext().peekOperand();
@@ -11761,7 +11761,7 @@ class UnitCompiler {
             || topOperand == StackMapTableAttribute.FLOAT_VARIABLE_INFO
             || topOperand == StackMapTableAttribute.DOUBLE_VARIABLE_INFO
         ) {
-            this.cmp(locatable, opIdx);
+            this.cmp(locatable, op);
             this.ifxx(locatable, opIdx, dst);
         } else
         {
@@ -11856,9 +11856,7 @@ class UnitCompiler {
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
      */
     private void
-    cmp(Locatable locatable, int opIdx) {
-        assert opIdx >= UnitCompiler.EQ && opIdx <= UnitCompiler.LE;
-
+    cmp(Locatable locatable, String op) {
         VerificationTypeInfo operand2 = this.getCodeContext().currentInserter().getStackMap().peekOperand();
         this.getCodeContext().popOperand();
         VerificationTypeInfo operand1 = this.getCodeContext().currentInserter().getStackMap().peekOperand();
@@ -11868,10 +11866,10 @@ class UnitCompiler {
             this.write(Opcode.LCMP);
         } else
         if (operand1 == StackMapTableAttribute.FLOAT_VARIABLE_INFO && operand2 == StackMapTableAttribute.FLOAT_VARIABLE_INFO) {
-            this.write(opIdx == UnitCompiler.GE || opIdx == UnitCompiler.GT ? Opcode.FCMPL : Opcode.FCMPG);
+            this.write(op == ">" || op == ">=" ? Opcode.FCMPL : Opcode.FCMPG);
         } else
         if (operand1 == StackMapTableAttribute.DOUBLE_VARIABLE_INFO && operand2 == StackMapTableAttribute.DOUBLE_VARIABLE_INFO) {
-            this.write(opIdx == UnitCompiler.GE || opIdx == UnitCompiler.GT ? Opcode.DCMPL : Opcode.DCMPG);
+            this.write(op == ">" || op == ">=" ? Opcode.DCMPL : Opcode.DCMPG);
         } else
         {
             throw new AssertionError(operand1 + " and " + operand2);

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -4389,7 +4389,7 @@ class UnitCompiler {
                 this.compileGetValue(bo.rhs);
                 this.numericPromotion(bo.rhs, this.convertToPrimitiveNumericType(bo.rhs, rhsType), promotedType);
 
-                this.ifNumeric(bo, bo.operator, opIdx, dst);
+                this.ifNumeric(bo, opIdx, dst);
                 return;
             }
 
@@ -11748,21 +11748,21 @@ class UnitCompiler {
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
      */
     private void
-    ifNumeric(Locatable locatable, String origOp, int opIdx, Offset dst) {
+    ifNumeric(BinaryOperation bo, int opIdx, Offset dst) {
         assert opIdx >= UnitCompiler.EQ && opIdx <= UnitCompiler.LE;
 
         VerificationTypeInfo topOperand = this.getCodeContext().peekOperand();
 
         if (topOperand == StackMapTableAttribute.INTEGER_VARIABLE_INFO) {
-            this.if_icmpxx(locatable, opIdx, dst);
+            this.if_icmpxx(bo, opIdx, dst);
         } else
         if (
             topOperand == StackMapTableAttribute.LONG_VARIABLE_INFO
             || topOperand == StackMapTableAttribute.FLOAT_VARIABLE_INFO
             || topOperand == StackMapTableAttribute.DOUBLE_VARIABLE_INFO
         ) {
-            this.cmp(locatable, origOp);
-            this.ifxx(locatable, opIdx, dst);
+            this.cmp(bo, bo.operator);
+            this.ifxx(bo, opIdx, dst);
         } else
         {
             throw new InternalCompilerException("Unexpected computational type \"" + topOperand + "\"");

--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -11746,6 +11746,7 @@ class UnitCompiler {
 
     /**
      * @param opIdx One of {@link #EQ}, {@link #NE}, {@link #LT}, {@link #GE}, {@link #GT} or {@link #LE}
+     * @param orientation {@link #JUMP_IF_TRUE} or {@link #JUMP_IF_FALSE}
      */
     private void
     ifNumeric(Locatable locatable, int opIdx, Offset dst, boolean orientation) {


### PR DESCRIPTION
This PR intends to fix the bug where a function (`func`) below returns an incorrect value when an input value (`x`) is `Double.NaN`; it should return false, but it returns true in janino v3.1.3/v3.1.2/v3.1.1 (v3.1.0 and the eariler ones don't have this issue).

```
// Java code
public boolean func(Double x) {
  if (x < 0.0) {
    return true;
  } else {
    return false;
  }
}
```

A dumped bytecode generated by janono v3.1.3 is as follows. An opcode in L5 should be `dcmpg` instead of `dcmpl` (I've checked java8+ and janino v3.1.0 generates `dcmpg` for the Java code).
```
// bytecode
public boolean func(java.lang.Double);
  descriptor: (Ljava/lang/Double;)Z
  flags: ACC_PUBLIC
  Code:
    stack=4, locals=2, args_size=2
       0: aload_1
       1: invokevirtual #12                 // Method java/lang/Double.doubleValue:()D
       4: dconst_0
       5: dcmpl             <==== !!!illegal opcode!!!
       6: ifge          11
       9: iconst_1
      10: ireturn
      11: iconst_0
      12: ireturn
```
It seems this bug occurred after refactoring `UnitCompiler` in the commit: https://github.com/janino-compiler/janino/commit/166789d22d6476731b4c63be633a56860429a0c7. This PR simply modified the code to handle the `if` condition in the same way as the code before the commit;
https://github.com/janino-compiler/janino/commit/166789d22d6476731b4c63be633a56860429a0c7#diff-18c4632e733d3dec0114fdf008870cee364b4aca252da65643cf74276805ce38L4257-L4262

I've checked all the existing tests can pass with this fix.

SIDE NOTE: This bug was found by @cloud-fan in https://github.com/apache/spark/pull/29495.