### PR TITLE
Fix the bug that wrongly trims local vars in a stack

### DIFF
--- a/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/ReportedBugsTest.java
+++ b/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/ReportedBugsTest.java
@@ -1220,6 +1220,39 @@ class ReportedBugsTest extends CommonsCompilerTestSuite {
         this.assertScriptCookable("import java.util.Map; Map<Long, Long> a;");
     }
 
+    @Test public void
+    testPullRequestXX() throws Exception {
+        this.assertCompilationUnitCookable((
+            ""
+            + "public class JaninoTest {\n"
+            + "    public int func(int v) {\n"
+            + "        long local_var0 = 0;\n"
+            + "        switch (v) {\n"
+            + "            case 0:\n"
+            + "                long local_var1 = 1;\n"
+            + "                local_var0 = local_var1;\n"
+            + "                break;\n"
+            + "\n"
+            + "            default:\n"
+            + "                long local_var2 = 2;\n"
+            + "                local_var0 = local_var2;\n"
+            + "                break;\n"
+            + "        }\n"
+            + "\n"
+            + "        long local_var3 = 1;\n"
+            + "        if (v % 4 == 0) {\n"
+            + "            local_var3 += 2;\n"
+            + "        }\n"
+            + "        if ((local_var0 + local_var3) % 2 == 0) {\n"
+            + "            return 0;\n"
+            + "        } else {\n"
+            + "            return 1;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n"
+        ));
+    }
+
     public ClassLoader
     compile(ClassLoader parentClassLoader, CompileUnit... compileUnits) {
 

--- a/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/ReportedBugsTest.java
+++ b/commons-compiler-tests/src/test/java/org/codehaus/commons/compiler/tests/ReportedBugsTest.java
@@ -1221,7 +1221,7 @@ class ReportedBugsTest extends CommonsCompilerTestSuite {
     }
 
     @Test public void
-    testPullRequestXX() throws Exception {
+    testPullRequest146() throws Exception {
         this.assertCompilationUnitCookable((
             ""
             + "public class JaninoTest {\n"

--- a/janino/src/main/java/org/codehaus/janino/CodeContext.java
+++ b/janino/src/main/java/org/codehaus/janino/CodeContext.java
@@ -232,7 +232,15 @@ class CodeContext {
         if (this.currentLocalScope != null) {
             StackMap sm = this.currentInserter.getStackMap();
             if (sm != null) {
-                while (sm.locals().length > this.allLocalVars.size()) sm = sm.popLocal();
+                int numLocalsInStackMap = 0;
+                for (VerificationTypeInfo slot : sm.locals()) {
+                    if (slot != StackMapTableAttribute.TOP_VARIABLE_INFO) {
+                        numLocalsInStackMap++;
+                    }
+                }
+                while (numLocalsInStackMap-- > this.allLocalVars.size()) {
+                    sm = sm.popLocal();
+                }
                 this.currentInserter.setStackMap(sm);
             }
         }


### PR DESCRIPTION
This PR intends to fix the bug where `CodeContext#restoreLocalVariables` wrongly trims local vars in a stack;
https://github.com/janino-compiler/janino/blob/f16db697aa9cae5761cd36dd42bae8456620923d/janino/src/main/java/org/codehaus/janino/CodeContext.java#L231-L238
The number of `sm.locals()` is not always the same with the number of `allLocalVars` because `sm.locals()` might contain the verification type `TOP_VARIABLE_INFO`. So, this PR excludes the type in `sm.locals()`  when checking whether we could trim `sm.locals()` or not. Since the logic to trim `sm.locals()` was merged in the commit https://github.com/janino-compiler/janino/commit/66af9f295493cc1653248dd10c75b90b976e3191, this issue can happen in janino-master/v3.1.3. Note that janino does not trim `sm.locals()` before the commit, so janino-v3.1.2 and the earlier versions does not have the issue.

This PR adds a new test in `ReportedBugsTest` and the test throws an exception below without this fix;
```
Running org.codehaus.commons.compiler.tests.ReportedBugsTest
Tests run: 122, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 12.29 sec <<< FAILURE! - in org.codehaus.commons.compiler.tests.ReportedBugsTest
testPullRequestXX[CompilerFactory=janino](org.codehaus.commons.compiler.tests.ReportedBugsTest)  Time elapsed: 0.012 sec  <<< ERROR!
org.codehaus.commons.compiler.InternalCompilerException: Compiling "JaninoTest" in Line 1, Column 8: Line 2, Column 16: Compiling "func(int v)": Line 20, Column 37: Compiling "(local_var0 + local_var3) % 2": Line 20, Column 14: Compiling "(local_var0 + local_var3)": Line 20, Column 27: Compiling "local_var3": Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
Caused by: org.codehaus.commons.compiler.InternalCompilerException: Line 2, Column 16: Compiling "func(int v)": Line 20, Column 37: Compiling "(local_var0 + local_var3) % 2": Line 20, Column 14: Compiling "(local_var0 + local_var3)": Line 20, Column 27: Compiling "local_var3": Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
Caused by: org.codehaus.commons.compiler.InternalCompilerException: Line 20, Column 37: Compiling "(local_var0 + local_var3) % 2": Line 20, Column 14: Compiling "(local_var0 + local_var3)": Line 20, Column 27: Compiling "local_var3": Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
Caused by: org.codehaus.commons.compiler.InternalCompilerException: Line 20, Column 14: Compiling "(local_var0 + local_var3)": Line 20, Column 27: Compiling "local_var3": Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
Caused by: org.codehaus.commons.compiler.InternalCompilerException: Line 20, Column 27: Compiling "local_var3": Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
Caused by: org.codehaus.commons.compiler.InternalCompilerException: Invalid local variable index 8
	at org.codehaus.commons.compiler.tests.ReportedBugsTest.testPullRequestXX(ReportedBugsTest.java:1225)
```
The code tries to reference the already-trimmed local var in a stack then it fails. I've checked that all the existing tests can pass with this fix merged.

SIDE NOTE: I found this bug when checking whether Spark can land on the latest janino. For example, a query below fails when using spark-master + janino-master/v3.1.3;
```
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.2.0-SNAPSHOT
      /_/
         
Using Scala version 2.12.10 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181)
Type in expressions to have them evaluated.
Type :help for more information.

scala> val df = Seq(("2016-03-27 19:39:34", 1, "a"), ("2016-03-27 19:39:56", 2, "a"), ("2016-03-27 19:39:27", 4, "b")).toDF("time", "value", "id")
scala> val rdf = df.select(window($"time", "10 seconds", "3 seconds", "0 second"), $"value").orderBy($"window.start".asc, $"value".desc).select("value")
scala> rdf.show()
21/04/26 23:11:07 ERROR CodeGenerator: failed to compile: org.codehaus.commons.compiler.InternalCompilerException: Compiling "GeneratedClass" in File 'generated.java', Line 1, Column 1: File 'generated.java', Line 32, Column 16: Compiling "processNext()": File 'generated.java', Line 2010, Column 6: Compiling "filter_isNull_3": Invalid local variable index 249
org.codehaus.commons.compiler.InternalCompilerException: Compiling "GeneratedClass" in File 'generated.java', Line 1, Column 1: File 'generated.java', Line 32, Column 16: Compiling "processNext()": File 'generated.java', Line 2010, Column 6: Compiling "filter_isNull_3": Invalid local variable index 249
	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:369)
	at org.codehaus.janino.UnitCompiler.access$000(UnitCompiler.java:231)
	at org.codehaus.janino.UnitCompiler$1.visitCompilationUnit(UnitCompiler.java:333)
	at org.codehaus.janino.UnitCompiler$1.visitCompilationUnit(UnitCompiler.java:330)
	at org.codehaus.janino.Java$CompilationUnit.accept(Java.java:367)
	at org.codehaus.janino.UnitCompiler.compileUnit(UnitCompiler.java:330)
	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:245)
	at org.codehaus.janino.ClassBodyEvaluator.cook(ClassBodyEvaluator.java:294)
	at org.codehaus.janino.ClassBodyEvaluator.cook(ClassBodyEvaluator.java:288)
	at org.codehaus.janino.ClassBodyEvaluator.cook(ClassBodyEvaluator.java:267)
	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:82)
	at org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator$.org$apache$spark$sql$catalyst$expressions$codegen$CodeGenerator$$doCompile(CodeGenerator.scala:1403)
	at org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator$$anon$1.load(CodeGenerator.scala:1501)
	at org.apache.spark.sql.catalyst.expressions.codegen.CodeGenerator$$anon$1.load(CodeGenerator.scala:1498)
    ...
```
See [this link ](https://gist.github.com/maropu/5f1ef1f4967b887e539a78cdbba98040) for the fully-generated code by Spark.