### PR TITLE
Add SUPER flag for package member types only

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
+++ b/janino/src/main/java/org/codehaus/janino/UnitCompiler.java
@@ -498,7 +498,7 @@ class UnitCompiler {
         }
 
         short accessFlags = this.accessFlags(cd.getModifiers());
-        accessFlags |= Mod.SUPER;
+        if (cd instanceof PackageMemberTypeDeclaration) accessFlags |= Mod.SUPER;
         if (cd instanceof EnumDeclaration) accessFlags |= Mod.ENUM;
 
         // Create "ClassFile" object.


### PR DESCRIPTION
As pointed out in this ticket: https://gitlab.ow2.org/asm/asm/-/issues/317968#note_82748, according to the java specification https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.7.6 it is disallowed to add `ACC_SUPER` flag for the `InnerClasses` attribute.

This issue affects the Apache Drill project. We use Janino for compiling the generated code and modifying it using the ASM library later.