### PR TITLE
Issue #202: Gracefully fallback if policy blocks reading system properties

### DIFF
--- a/commons-compiler/src/main/java/org/codehaus/commons/compiler/util/SystemProperties.java
+++ b/commons-compiler/src/main/java/org/codehaus/commons/compiler/util/SystemProperties.java
@@ -89,11 +89,21 @@ class SystemProperties {
     @Nullable public static String
     getClassProperty(Class<?> targetClass, String classPropertyName, @Nullable String defaultValue) {
 
-        String result = System.getProperty(targetClass.getName() + "." + classPropertyName);
-        if (result != null) return result;
+        String result;
 
-        result = System.getProperty(targetClass.getSimpleName() + "." + classPropertyName);
-        if (result != null) return result;
+        try {
+            result = System.getProperty(targetClass.getName() + "." + classPropertyName);
+            if (result != null) return result;
+        } catch (RuntimeException e) {
+            // Do nothing, e.g. if blocked by security policy
+        }
+
+        try {
+            result = System.getProperty(targetClass.getSimpleName() + "." + classPropertyName);
+            if (result != null) return result;
+        } catch (RuntimeException e) {
+            // Do nothing, e.g. if blocked by security policy
+        }
 
         return defaultValue;
     }


### PR DESCRIPTION
(Implementation for https://github.com/janino-compiler/janino/issues/202)

I'm trying to run Janino in an environment where the Java Security Manager restricts reading system properties unless specifically permitted. (Yes, my organization's IT department relies on Java's Security Manager, despite the fact Oracle has deprecated it and plans to remove it. I'm not in charge of that decision.)

When the Security Manager blocks reading a property, it throws a security exception where the read was attempted. I can petition my IT department to add new system properties, but the process is bureaucratic and slow.

Between 3.1.6 and 3.1.9, Janino started reading several System Properties while loading the classes AbstractCompiler and SimpleCompiler. I have successfully petitioned the security folks to permit loading system properties from a wildcard (org.janino.*), but the fallback mechanism in SystemProperties.java -- whereby it checks for a full classpath, but falls back to the class' simple name if another value is not found -- makes it very difficult to write a policy exception because every time a new class in Janino reads a system property, we'd have to account for it.

I propose wrapping these reads in a simple try/catch block.