### PR TITLE
Correctly parse and unparse annotated wildcard types

### DIFF
--- a/janino/src/main/java/org/codehaus/janino/Java.java
+++ b/janino/src/main/java/org/codehaus/janino/Java.java
@@ -6438,15 +6438,20 @@ class Java {
         public final int bounds;
 
         /**
+         * The annotations of the wildcard type, defined by JLS8, 4.5.1 since JLS8.
+         */
+        public final Annotation[] annotations;
+
+        /**
          * The reference type of this wildcard's EXTENDS or SUPER bounds.
          */
         @Nullable public final ReferenceType referenceType;
 
         public
-        Wildcard() { this(Wildcard.BOUNDS_NONE, null); }
+        Wildcard(Annotation[] annotations) { this(Wildcard.BOUNDS_NONE, null, annotations); }
 
         public
-        Wildcard(int bounds, @Nullable ReferenceType referenceType) {
+        Wildcard(int bounds, @Nullable ReferenceType referenceType, Annotation[] annotations) {
             if (referenceType == null) {
                 assert bounds == Wildcard.BOUNDS_NONE;
                 this.bounds        = bounds;
@@ -6456,6 +6461,9 @@ class Java {
                 this.bounds        = bounds;
                 this.referenceType = referenceType;
             }
+
+            assert annotations != null;
+            this.annotations = annotations;
         }
 
         @Override public void
@@ -6468,7 +6476,9 @@ class Java {
 
         @Override public String
         toString() {
-            return (
+            String s = Java.join(this.annotations, " ");
+            if (this.annotations.length >= 1) s += ' ';
+            return s + (
                 this.bounds == Wildcard.BOUNDS_EXTENDS ? "? extends " + this.referenceType :
                 this.bounds == Wildcard.BOUNDS_SUPER   ? "? super "   + this.referenceType :
                 "?"

--- a/janino/src/main/java/org/codehaus/janino/util/DeepCopier.java
+++ b/janino/src/main/java/org/codehaus/janino/util/DeepCopier.java
@@ -484,7 +484,11 @@ class DeepCopier {
 
     public TypeArgument
     copyWildcard(Wildcard subject) throws CompileException {
-        return new Wildcard(subject.bounds, this.copyOptionalReferenceType(subject.referenceType));
+        return new Wildcard(
+            subject.bounds,
+            this.copyOptionalReferenceType(subject.referenceType),
+            this.copyAnnotations(subject.annotations)
+        );
     }
 
     public PackageDeclaration

--- a/janino/src/test/java/org/codehaus/janino/tests/UnparserTest.java
+++ b/janino/src/test/java/org/codehaus/janino/tests/UnparserTest.java
@@ -656,6 +656,11 @@ class UnparserTest {
         UnparserTest.helpTestScript("{ return a              -> {};    }");
         UnparserTest.helpTestScript("{ return (int a, int b) -> {};    }");
         UnparserTest.helpTestScript("{ return ()             -> 3 + 7; }");
+
+        // Annotated wildcards (JLS8, 4.5.1).
+        UnparserTest.helpTestScript(
+            "{ java.util.Map<?, ?> map = new java.util.HashMap<@WildcardAnnotation ? extends String, ? extends @TypeAnnotation Integer>(); }"
+        );
     }
 
     @Test public void


### PR DESCRIPTION
Note that this does not mean that the wildcard annotations show up when compiled. I've had little luck with getting janino to produce signatures in the class bytecode in the first place. Hence the tests relevant to this PR are only constrained to the Unparser while the larger compile tests were left alone.

The fact that wildcard tpyes can be annotated is not really well defined within the JLS: The only definition of this behaviour can be found in JLS8, 4.5.1 within the syntax of wildcards, which is then repeated in JLS8 section 18. But there is otherwise no supporting evidence. Outside the JLS, JVMS8, section 4.7.20.2 lists a few examples on where annotations appear, one of which is our wildcard annotation. It also seems to define that annotations which are on the right hand of a wildcard have a type_path_kind value of 2. Those on the left hand (which this PR implements) are not directly associated with the wildcard and have a type_path_kind value of 3 (as they referr to the type represented by the wildcard, not the bounds)

---

Note that local variable declarations seem to not support annotated types, this PR does not touch those and as such annotating the type arguments for them still continues to fail - with and without wildcards.

Also, I am aware that the Unparser test contains code that shouldn't compile, but I expect this to not be a concern since the code will never get compiled anyways. Should my expectation be false, please do notify me about that however.